### PR TITLE
fix(Provider): Don't return empty string when failed to translate

### DIFF
--- a/lib/Provider/Translation.php
+++ b/lib/Provider/Translation.php
@@ -66,7 +66,7 @@ class Translation implements ITranslationProvider, IDetectLanguageProvider {
 			return trim($this->translator->seq2seq($model, $text));
 		} catch(\RuntimeException $e) {
 			$this->logger->warning('Translation failed with: ' . $e->getMessage(), ['exception' => $e]);
-			return '';
+			throw $e;
 		}
 	}
 }


### PR DESCRIPTION
### Steps

1. Download `de-en` only
2. Send a translation request for `en-es`

### Before

😕  OK 200 ?

```
curl -k 'https://nextcloud27.local/ocs/v2.php/translation/translate?text=calculate&fromLanguage=en&toLanguage=es&format=json' -u admin:admin -H 'OCS-APIRequest: true' -v -X POST
{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"text":""}}}
```

### After

😿 Error 500 ?
(Probably should be a 400 or something, but that needs changing in server)

```
curl -k 'https://nextcloud27.local/ocs/v2.php/translation/translate?text=calculate&fromLanguage=en&toLanguage=es&format=json' -u admin:admin -H 'OCS-APIRequest: true' -v -X POST
{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"message":"Unable to translate","0":500}}}
```